### PR TITLE
Fix the UserAction count in callConvo.js

### DIFF
--- a/backend/app/conversations/callConvo.js
+++ b/backend/app/conversations/callConvo.js
@@ -88,9 +88,9 @@ function areYouReadyConvo(user, message) {
 function readyResponseConvo(user, message) {
   return UserAction.create({
     actionType: message.text,
-    campaignAction: user.convoData.campaignCall,
+    campaignCall: user.convoData.campaignCall._id,
     representative: user.convoData.representatives[user.convoData.currentRepresentativeIndex].repId,
-    user: user,
+    user: user._id,
   })
   .then(() => {
     if (message.text === ACTION_TYPE_PAYLOADS.isReady) {
@@ -220,14 +220,14 @@ function howDidItGoConvo(user, message) {
 function howDidItGoResponseConvo(user, message) {
   return UserAction.create({
     actionType: message.text,
-    campaignAction: user.convoData.campaignCall,
+    campaignCall: user.convoData.campaignCall._id,
     representative: user.convoData.representatives[user.convoData.currentRepresentativeIndex].repId,
-    user: user,
+    user: user._id,
   })
   .then(() => {
     if ([ACTION_TYPE_PAYLOADS.voicemail, ACTION_TYPE_PAYLOADS.staffer].indexOf(message.text) >= 0) {
       const userActionCountPromise = UserAction.count({
-        campaignAction: user.convoData.campaignCall,
+        campaignCall: user.convoData.campaignCall._id,
         actionType: {
           $in: [
             ACTION_TYPE_PAYLOADS.voicemail,
@@ -341,9 +341,9 @@ function howDidItGoResponseConvo(user, message) {
 function tryNextRepResponseConvo(user, message) {
   return UserAction.create({
     actionType: message.text,
-    campaignAction: user.convoData.campaignCall,
+    campaignCall: user.convoData.campaignCall._id,
     representative: user.convoData.representatives[user.convoData.currentRepresentativeIndex].repId,
-    user: user,
+    user: user._id,
   })
   .then(() => {
     if (message.text === ACTION_TYPE_PAYLOADS.tryNextRep) {


### PR DESCRIPTION
Resolves #164 

We were creating/querying `UserActions` based on the `campaignAction` field, which wasn't working because we previously refactored the `UserAction` model to keep track of a `campaignCall` id instead of a `campaignAction` id.