### PR TITLE
Set up database migrations

### DIFF
--- a/backend/bash/create_migration.sh
+++ b/backend/bash/create_migration.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+BASEDIR=$( cd $(dirname $(dirname $0)) ; pwd -P )
+cd $BASEDIR/../
+source $BASEDIR/../.env
+
+MIGRATION_NAME=$1
+./node_modules/.bin/migrate -d $MONGODB_URI create $MIGRATION_NAME --es6

--- a/backend/bash/list_migrations.sh
+++ b/backend/bash/list_migrations.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+BASEDIR=$( cd $(dirname $(dirname $0)) ; pwd -P )
+cd $BASEDIR/../
+source $BASEDIR/../.env
+./node_modules/.bin/migrate -d $MONGODB_URI list --es6 --autosync

--- a/backend/bash/rollback_migrations.sh
+++ b/backend/bash/rollback_migrations.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+BASEDIR=$( cd $(dirname $(dirname $0)) ; pwd -P )
+cd $BASEDIR/../
+source $BASEDIR/../.env
+
+MIGRATION_NAME=$1
+./node_modules/.bin/migrate -d $MONGODB_URI down $MIGRATION_NAME --es6 --autosync

--- a/backend/bash/run_migrations.sh
+++ b/backend/bash/run_migrations.sh
@@ -6,7 +6,7 @@ source $BASEDIR/../.env
 
 MIGRATION_NAME=$1
 if [ -z "$MIGRATION_NAME" ]; then
-  ./node_modules/.bin/migrate -d $MONGODB_URI --es6 --autosync up --es6 --autosync
+  ./node_modules/.bin/migrate -d $MONGODB_URI --es6 --autosync up --es6 --autosync || :
 else
-  ./node_modules/.bin/migrate -d $MONGODB_URI up $MIGRATION_NAME --es6 --autosync
+  ./node_modules/.bin/migrate -d $MONGODB_URI up $MIGRATION_NAME --es6 --autosync || :
 fi

--- a/backend/bash/run_migrations.sh
+++ b/backend/bash/run_migrations.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+BASEDIR=$( cd $(dirname $(dirname $0)) ; pwd -P )
+cd $BASEDIR/../
+source $BASEDIR/../.env
+
+MIGRATION_NAME=$1
+if [ -z "$MIGRATION_NAME" ]; then
+  ./node_modules/.bin/migrate -d $MONGODB_URI --es6 --autosync up --es6 --autosync
+else
+  ./node_modules/.bin/migrate -d $MONGODB_URI up $MIGRATION_NAME --es6 --autosync
+fi

--- a/backend/devops/deploy_tasks.yml
+++ b/backend/devops/deploy_tasks.yml
@@ -60,6 +60,9 @@
       hour: 0
       minute: 0
 
+  - name: run database migrations
+    command: "{{backend_dir}}/bash/run_migrations.sh"
+
   - name: Start pm2 (auto-restarts if already started)
     command: "{{node_bin}}/pm2 start {{config_dir}}/pm2.json"
     become: true

--- a/backend/migrations/1489350295898-empty_migration.js
+++ b/backend/migrations/1489350295898-empty_migration.js
@@ -1,0 +1,14 @@
+
+/**
+ * Make any changes you need to make to the database here
+ */
+export async function up () {
+  // Write migration here
+}
+
+/**
+ * Make any changes that UNDO the up function side effects here (if possible)
+ */
+export async function down () {
+  // Write migration here
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "js-yaml": "^3.7.0",
     "jsonpointer": "^4.0.0",
     "jsonwebtoken": "^7.2.1",
+    "migrate-mongoose": "^3.2.2",
     "moment": "^2.17.1",
     "mongodb": "^2.1.20",
     "mongoose": "^4.8.2",


### PR DESCRIPTION
Resolves #163 

* Set up [migrate-mongoose](https://github.com/balmasi/migrate-mongoose), a library for handling database migrations with mongoose.
* Add several bash scripts for working with migrations
  * `./backend/bash/list_migrations.sh` will list all existing migrations
  * `./backend/bash/create_migration.sh <migration_name>` will create a new migration
  * `./backend/bash/run_migrations.sh` will run all existing migrations
  * `./backend/bash/run_migrations.sh <migration_name` will run all existing migrations, up to <migration_name>
  * `./backend/bash/rollback_migrations.sh <migration_name>` will undo all existing migrations, down to <migration_name>