### PR TITLE
User Conversation table for campaignActionDetail

### DIFF
--- a/backend/app/conversations/callConvo.js
+++ b/backend/app/conversations/callConvo.js
@@ -63,9 +63,6 @@ function startCallConversation(user, userConversation, representatives, campaign
 
 // part 1
 function areYouReadyConvo(user, message) {
-  // set that the conversation has been intialized
-  // (we could consider putting this after the first set of messages instead of before)
-  UserConversation.update({ _id: user.convoData.userConversationId }, { active: true }).exec()
   // begin the conversation
   return botReply(user,
     `Hi ${user.convoData.firstName}. We've got an issue that needs your action.`

--- a/backend/app/methods/campaignCallMethods.js
+++ b/backend/app/methods/campaignCallMethods.js
@@ -1,6 +1,6 @@
 const { CampaignCall } = require('../models')
 
-function getCampaignCall(req, res) {
+function getCampaignCallDetail(req, res) {
   return CampaignCall
     .findById(req.params.id)
     .populate('campaignUpdates userActions')
@@ -22,6 +22,15 @@ function getCampaignCall(req, res) {
     .catch(err => res.send(err))
 }
 
+function getCampaignCall(req, res) {
+  return CampaignCall
+    .findById(req.params.id)
+    .exec()
+    .then(campaignCallObject => res.json(campaignCallObject))
+    .catch(err => res.send(err))
+}
+
 module.exports = {
-  getCampaignCall
+  getCampaignCall,
+  getCampaignCallDetail
 }

--- a/backend/app/methods/campaignMethods.js
+++ b/backend/app/methods/campaignMethods.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose')
 const { Campaign, CampaignCall, CampaignUpdate, UserConversation } = require('../models')
+const USER_CONVO_STATUS = UserConversation.USER_CONVO_STATUS
 
 const ObjectId = mongoose.Types.ObjectId
 
@@ -89,7 +90,8 @@ exports.newCampaignCall = function(req, res) {
           campaignAction: ObjectId(savedCampaignCall._id),
           convoData: {
             representatives: repIds,
-          }
+          },
+          status: USER_CONVO_STATUS.pending,
         })
         userConvoPromises.push(userConvoPromise)
       }
@@ -130,7 +132,8 @@ exports.newCampaignUpdate = function(req, res) {
         const user = users[i]
         const userConvoPromise = UserConversation.create({
           user: ObjectId(user._id),
-          campaignAction: ObjectId(savedCampaignUpdate._id)
+          campaignAction: ObjectId(savedCampaignUpdate._id),
+          status: USER_CONVO_STATUS.pending,
         })
         userConvoPromises.push(userConvoPromise)
       }

--- a/backend/app/methods/campaignUpdateMethods.js
+++ b/backend/app/methods/campaignUpdateMethods.js
@@ -1,6 +1,6 @@
 const { CampaignUpdate } = require('../models')
 
-function getCampaignUpdate(req, res) {
+function getCampaignUpdateDetail(req, res) {
   return CampaignUpdate
     .findById(req.params.id)
     .populate({
@@ -31,5 +31,5 @@ function getCampaignUpdate(req, res) {
 }
 
 module.exports = {
-  getCampaignUpdate
+  getCampaignUpdateDetail
 }

--- a/backend/app/models/campaignUpdate.js
+++ b/backend/app/models/campaignUpdate.js
@@ -6,7 +6,7 @@ const campaignUpdateSchema = new Schema({
   message: String,
   campaignCall: { type: Schema.Types.ObjectId, ref: 'CampaignCall' }
 }, {
-  discriminatorKey: 'type'
+  discriminatorKey: 'type',
 })
 
 module.exports = CampaignAction.discriminator('CampaignUpdate', campaignUpdateSchema)

--- a/backend/app/models/userConversation.js
+++ b/backend/app/models/userConversation.js
@@ -2,13 +2,24 @@ const moment = require('moment')
 const mongoose = require('mongoose')
 const Schema = mongoose.Schema
 
+const USER_CONVO_STATUS = {
+  error: 'error',
+  pending: 'pending',
+  sent: 'sent',
+}
+
 const userConversationSchema = new Schema({
-  active: { type: Boolean, default: false },
   user: { type: Schema.Types.ObjectId, ref: 'User' },
   campaignAction: { type: Schema.Types.ObjectId, ref: 'CampaignAction' },
-  datePrompted:  { type: Date, default: () => moment.utc().toDate() },
+  datePrompted:  { type: Date },
   dateCompleted: Date,
   convoData: Schema.Types.Mixed,  // data which is needed to send this UserConversation
+  status: {
+    type: String,
+    enum: Object.values(USER_CONVO_STATUS)
+  },
 })
+
+userConversationSchema.statics.USER_CONVO_STATUS = USER_CONVO_STATUS
 
 module.exports = mongoose.model('UserConversation', userConversationSchema)

--- a/backend/app/routes/adminRoutes.js
+++ b/backend/app/routes/adminRoutes.js
@@ -43,9 +43,9 @@ module.exports = function(apiRouter) {
     }
 
     if (type === 'CampaignCall') {
-      return campaignCallMethods.getCampaignCall(req, res)
+      return campaignCallMethods.getCampaignCallDetail(req, res)
     } else {
-      return campaignUpdateMethods.getCampaignUpdate(req, res)
+      return campaignUpdateMethods.getCampaignUpdateDetail(req, res)
     }
   })
 

--- a/backend/app/utilities/representatives.js
+++ b/backend/app/utilities/representatives.js
@@ -65,7 +65,7 @@ async function loadRepsFromFile() {
 
 async function fetchOfficeLocationsFromPhoneYourRep() {
   const repsData = await rp({ uri: 'https://phone-your-rep.herokuapp.com/reps/', json: true })
-  return repsData.reps.reduce((acc, rep) => Object.assign(acc, { [rep.bioguide_id]: rep.office_locations }), {})
+  return repsData.reduce((acc, rep) => Object.assign(acc, { [rep.bioguide_id]: rep.office_locations }), {})
 }
 
 module.exports = {

--- a/frontend/app/CampaignActionDetail.js
+++ b/frontend/app/CampaignActionDetail.js
@@ -1,23 +1,88 @@
-import React from 'react'
+import React, { Component } from 'react'
 import Loader from 'react-loader'
 import moment from 'moment'
+import Modal from 'react-modal'
 import API from './API'
 import CampaignCallPreview from './CampaignCallPreview'
 
 const DATE_FORMAT = 'h:mma on M/DD/YYYY'
+
+// used in both the NewCampaignUpdate and NewAction components
+const CONFIRMATION_MODAL_STYLE = {
+  content: {
+    top: '50%',
+    left: '50%',
+    right: '',
+    bottom: '',
+    transform: 'translate(-50%, -50%)',
+    width: '100%',
+    maxWidth: '300px',
+    height: '100%',
+    maxHeight: '135px',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center'
+  }
+}
+
+function compareUserConvos(a, b) {
+  if (a.user.firstName < b.user.firstName) {
+    return 1
+  } else if (a.user.lastName < b.user.lastName) {
+    return 1
+  } else {
+    return -1
+  }
+}
+
+class UserConvoItem extends Component {
+  render() {
+
+    let numUserCalls = null
+    if (this.props.userConvo.convoData) {
+      numUserCalls = this.props.userConvo.convoData.numUserCalls
+    }
+
+    // TODO: calculate X as number of reps
+    return <tr>
+      <td>{this.props.userConvo.user.id}</td>
+      <td>{this.props.userConvo.user.firstName} {this.props.userConvo.user.lastName}</td>
+      <td>{this.props.userConvo.status}</td>
+      <td>{this.props.userConvo.datePrompted}</td>
+      <td>{numUserCalls ? numUserCalls + '/ X' : ''}</td>
+    </tr>
+  }
+}
 
 export default class CampaignActionDetail extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
       action: {},
-      loaded: false
+      loaded: false,
+      confirmationModalIsOpen: false,
     }
     this.fetchCampaignAction = this.fetchCampaignAction.bind(this)
   }
 
+  static get contextTypes() {
+    return { notify: React.PropTypes.func.isRequired }
+  }
+
   componentWillMount() {
     this.fetchCampaignAction()
+    var intervalId = setInterval(() => {
+      console.log('++ updating campaign action')
+      this.fetchCampaignAction()
+    }, 1000)
+    this.setState({intervalId: intervalId})
+  }
+
+  componentWillUnmount() {
+    if (this.state.intervalId) {
+      clearInterval(this.state.intervalId)
+    }
   }
 
   fetchCampaignAction() {
@@ -43,7 +108,7 @@ export default class CampaignActionDetail extends React.Component {
     const userConversationsCount  = this.state.action.userConversations ? this.state.action.userConversations.length : 0
     const stats = [
       { label: 'Members targeted', value: this.representativesCount },
-      { label: 'Constituents sent', value: userConversationsCount }
+      { label: 'Constituents targeted', value: userConversationsCount }
     ]
 
     if (this.state.action.type === 'CampaignCall') {
@@ -63,22 +128,59 @@ export default class CampaignActionDetail extends React.Component {
     )
   }
 
+  closeConfirmationModal = () => {
+    this.setState({ confirmationModalIsOpen: false })
+  }
+
   get preview() {
     switch (this.state.action.type) {
       case 'CampaignCall':
         return  <CampaignCallPreview campaignCall={this.state.action} />
       case 'CampaignUpdate':
-        return null
+        return this.state.action.message
       default:
         return null
     }
   }
 
-  render() {
+  sendAction = () => {
+    this.closeConfirmationModal()
+    const notifyCallback = () => {
+      this.context.notify({
+        message: 'Sent',
+        level: 'success',
+        autoDismiss: 1,
+        onRemove: () => {}
+      })
+    }
+    switch (this.state.action.type) {
+      case 'CampaignCall':
+          return API.sendCampaignCall(this.state.action.id).then(notifyCallback)
+      case 'CampaignUpdate':
+          return API.sendCampaignUpdate(this.state.action.id).then(notifyCallback)
+      default:
+          console.log('++ invalid campaign action type')
+          return null
+    }
+  }
+
+  render = () => {
     const createdAt = moment.utc(this.state.action.createdAt).local().format(DATE_FORMAT)
     const actionTypeLabels = {
       CampaignCall: 'Call',
       CampaignUpdate: 'Update'
+    }
+
+    const userConversations = this.state.action.userConversations
+    let userConvos = null
+    if (userConversations) {
+      userConvos = this.state.action.userConversations.sort(compareUserConvos).map((userConvo, i) => {
+        return <UserConvoItem
+          key={i}
+          num={i}
+          userConvo={userConvo}
+        />
+      })
     }
 
     return (
@@ -89,6 +191,10 @@ export default class CampaignActionDetail extends React.Component {
             <h4>Created at {createdAt}</h4>
           </div>
 
+          {this.state.action.sent
+            ? null
+            : <div className="preview-warning">This is a preview and has not been sent yet</div>}
+
           <div className="meta">
             <h1>{actionTypeLabels[this.state.action.type]}</h1>
             {this.statistics}
@@ -98,6 +204,37 @@ export default class CampaignActionDetail extends React.Component {
             {this.preview}
           </div>
 
+          <div className="sent-to">
+            <h1>Sent To</h1>
+            <button className="send-button" onClick={() => this.setState({ confirmationModalIsOpen: true })}>Send</button>
+          </div>
+
+          <Modal
+            isOpen={this.state.confirmationModalIsOpen}
+            style={CONFIRMATION_MODAL_STYLE}
+            contentLabel="Confirm"
+          >
+            <p style={{ marginBottom: '10px' }}>Are you sure?</p>
+            <div>
+              <button onClick={this.sendAction} style={{ marginRight: '10px' }}>Yes</button>
+              <button onClick={this.closeConfirmationModal}>No</button>
+            </div>
+          </Modal>
+
+          <div className="userconvo-table table">
+            <table>
+              <tbody>
+                <tr>
+                  <th>#</th>
+                  <th>User</th>
+                  <th>Status</th>
+                  <th>Date Received</th>
+                  <th>NumCalls</th>
+                </tr>
+                {userConvos}
+              </tbody>
+            </table>
+          </div>
         </div>
       </Loader>
     )

--- a/frontend/app/CampaignActionDetail.js
+++ b/frontend/app/CampaignActionDetail.js
@@ -27,9 +27,9 @@ const CONFIRMATION_MODAL_STYLE = {
 }
 
 function compareUserConvos(a, b) {
-  if (a.user.firstName < b.user.firstName) {
+  if (a.user.firstName > b.user.firstName) {
     return 1
-  } else if (a.user.lastName < b.user.lastName) {
+  } else if (a.user.lastName > b.user.lastName) {
     return 1
   } else {
     return -1
@@ -174,7 +174,8 @@ export default class CampaignActionDetail extends React.Component {
     const userConversations = this.state.action.userConversations
     let userConvos = null
     if (userConversations) {
-      userConvos = this.state.action.userConversations.sort(compareUserConvos).map((userConvo, i) => {
+      const sortedUserConversations = this.state.action.userConversations.sort(compareUserConvos)
+      userConvos = sortedUserConversations.map((userConvo, i) => {
         return <UserConvoItem
           key={i}
           num={i}

--- a/frontend/app/NewCampaignAction.js
+++ b/frontend/app/NewCampaignAction.js
@@ -86,13 +86,12 @@ class NewCampaignUpdate extends Component {
       this.state.campaign.id,
       this.state.update,
       (campaignUpdate) => {
-        API.sendCampaignUpdate(campaignUpdate.id)
         this.context.notify({
           message: 'Update created',
           level: 'success',
           autoDismiss: 1,
           onRemove: () => {
-            this.props.router.push(`/${this.state.campaign.id}`)
+            this.props.router.push(`/{this.state.campaign.id}/actions/${campaignUpdate.id}`)
           }
         })
       }
@@ -120,7 +119,10 @@ class NewCampaignUpdate extends Component {
   }
 
   render = () => {
-    const notUpdates = this.state.campaign.campaignActions.filter(a => a.type !== 'CampaignUpdate')
+    let notUpdates = []
+    if (this.state.campaign.campaignActions) {
+      notUpdates = this.state.campaign.campaignActions.filter(a => a.type !== 'CampaignUpdate')
+    }
     const options = notUpdates.map(a => ({
       value: a.id,
       label: a.title
@@ -146,7 +148,7 @@ class NewCampaignUpdate extends Component {
             <label htmlFor="message">Message</label>
             <textarea id="message" value={this.state.update.message} onChange={this.onMessageChange} />
           </fieldset>
-          <input type="submit" value="Send" />
+          <input type="submit" value="Create" />
         </form>
         <div className="preview">
           <h4>Preview</h4>
@@ -279,15 +281,13 @@ class NewCampaignCall extends Component {
       this.state.campaign.id,
       this.state.campaignCall,
       (campaignCall) => {
-        // start the CampaignCall after it has been created (this can be async, we don't need to wait for response)
-        API.sendCampaignCall(campaignCall.id)
         this.context.notify({
           message: 'Action created',
           level: 'success',
           autoDismiss: 1,
-          // TODO: redirect to CampaignActionDetail page for newly created CampaignAction
+          // redirect to CampaignActionDetail page for newly created CampaignAction
           onRemove: () => {
-            this.props.router.push(`/${this.state.campaign.id}`)
+            this.props.router.push(`/${this.state.campaign.id}/actions/${campaignCall.id}`)
           }
         })
       })
@@ -393,7 +393,7 @@ class NewCampaignCall extends Component {
               onChange={this.onInputChange.bind(this, 'task')}
               ref={(input) => { this.inputs.task = input }} />
           </fieldset>
-          <input type="submit" value="Send" />
+          <input type="submit" value="Create" />
         </form>
         <div className="preview">
           <CampaignCallPreview campaignCall={this.state.campaignCall} focusInput={this.focusInput.bind(this)} />

--- a/frontend/css/main.sass
+++ b/frontend/css/main.sass
@@ -68,6 +68,27 @@ button, input[type=button]
     padding: 1em
     text-align: left
 
+.sent-to
+  margin-top: 80px
+  float: left
+  width: 100%
+  h1
+    float: left
+  .send-button
+    margin-left: 20px
+    float: left
+
+.userconvo-table
+  margin-top: 20px
+  float: left
+  width: 100%
+
+.preview-warning
+  padding: 20px
+  width: 400px
+  border: 1px solid black
+  margin-bottom: 20px
+
 .preview-message
   background: #4080FF
   border-radius: 1em


### PR DESCRIPTION
CampaignActionDetail page has table of UserConversation which shows which users are pending/sent/error 

When you first create a CampaignAction it does not send immediately 
instead, you have to click send on the CampaignActionDetail page (there also is confirmation modal here) 

Not a ton of polish in this PR. Think of this as a hot fix for right now to avoid accidentally sending campaigns to people wen don't mean to send them to 
... as well as the beginning of work towards a more polished campaign action detail page 

in the future I think the UI could be updated a bit to make it more clear this is a preview page 
... there is enough shared functionality between preview and detail page that maybe they should be the same page (but we could think about how the UI could do both of this things.. or how there could be small differences between them)........... but for now this works (even included a lil warning label at the top which tells you if you are still looking at an unsent preview)