### PR TITLE
Add babel-polyfill to webpack build pipeline to fix Object.values error

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "babel-polyfill": "^6.23.0",
     "classnames": "^2.2.5",
     "moment": "^2.17.1",
     "raven-js": "^3.10.0",

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -14,7 +14,7 @@ else {
 }
 
 module.exports = {
-  entry: ['react-hot-loader/patch', 'whatwg-fetch', './main'],
+  entry: ['react-hot-loader/patch', 'babel-polyfill', 'whatwg-fetch', './main'],
   output: {
     path: params.BUILD_DIR,
     filename: 'bundle.js',


### PR DESCRIPTION
On Safari, the admin front-end was throwing an error: ```Object.values is not defined```

Adding [babel-polyfill](https://babeljs.io/docs/usage/polyfill/) to the webpack build ensures that `Object.values`, `Object.entries`, and other relatively new JS features will be available across all browsers.