### PR TITLE
Set user's callback path to /default before sending a CampaignUpdate

### DIFF
--- a/backend/app/conversations/updateConvo.js
+++ b/backend/app/conversations/updateConvo.js
@@ -1,7 +1,9 @@
+const { setUserCallback } = require('../methods/userMethods')
 const botReply = require('../utilities/botkit').botReply
 
 
-var startUpdateConversation = function(user, userConversation, campaignUpdate) {
+async function startUpdateConversation(user, userConversation, campaignUpdate) {
+  await setUserCallback(user, '/default')
   return botReply(user, campaignUpdate.message)
 }
 

--- a/frontend/app/CampaignActionDetail.js
+++ b/frontend/app/CampaignActionDetail.js
@@ -144,6 +144,10 @@ export default class CampaignActionDetail extends React.Component {
   sendAction() {
     this.closeConfirmationModal()
     const notifyCallback = () => {
+      const action = this.state.action
+      action.sent = true
+      this.setState({ action: action })
+
       this.context.notify({
         message: 'Sent',
         level: 'success',


### PR DESCRIPTION
Resolves #289 

Also set `action.sent` state to `true` on the frontend after successfully sending a CampaignAction.