### PR TITLE
Multi-tenant login

### DIFF
--- a/backend/app/methods/campaignMethods.js
+++ b/backend/app/methods/campaignMethods.js
@@ -7,7 +7,7 @@ const ObjectId = mongoose.Types.ObjectId
 exports.newCampaign = function(req, res) {
 
   // get bot from currently logged in admin
-  const bot = process.env.DEFAULT_BOT // TODO: actually get this from admin user associated with session token
+  const bot = req.user.bot
 
   // process request
   const data = req.body
@@ -25,7 +25,7 @@ exports.newCampaign = function(req, res) {
 exports.modifyCampaign = function(req, res) {
 
   // get bot from currently logged in admin
-  const bot = process.env.DEFAULT_BOT // TODO: actually get this from admin user associated with session token
+  const bot = req.user.bot
 
   // update campaign
   return Campaign.update({_id: req._id, bot: bot}, {
@@ -43,7 +43,7 @@ exports.modifyCampaign = function(req, res) {
 exports.getCampaign = function(req, res) {
 
   // get bot from currently logged in admin
-  const bot = process.env.DEFAULT_BOT // TODO: actually get this from admin user associated with session token
+  const bot = req.user.bot
 
   // return campaign
   return Campaign
@@ -62,7 +62,7 @@ exports.getCampaign = function(req, res) {
 
 exports.getCampaigns = function(req, res) {
   // get bot from currently logged in admin
-  const bot = process.env.DEFAULT_BOT // TODO: actually get this from admin user associated with session token
+  const bot = req.user.bot
 
   // return campaigns
   Campaign
@@ -82,7 +82,7 @@ exports.getCampaigns = function(req, res) {
 exports.newCampaignAction = async function(req, res) {
 
   // get bot from currently logged in admin
-  const bot = process.env.DEFAULT_BOT // TODO: actually get this from admin user associated with session token
+  const bot = req.user.bot
 
   // assert that campaign.bot is the same as currently logged in bot
   const campaign = await Campaign.findOne({ _id: req.params.id, bot: bot })

--- a/backend/app/models/adminUser.js
+++ b/backend/app/models/adminUser.js
@@ -1,0 +1,46 @@
+const bcrypt = require('bcrypt')
+const mongoose = require('mongoose')
+const Schema = mongoose.Schema
+const SALT_WORK_FACTOR = 10
+
+const adminUserSchema = new Schema({
+  username: { type: String, required: true, index: { unique: true } },
+  password: { type: String, required: true },
+  bot: { type: String, required: true }
+})
+
+adminUserSchema.pre('save', function hashPassword(next) {
+  const user = this
+
+  if (!user.isModified('password')) {
+    return next()
+  }
+
+  bcrypt.genSalt(SALT_WORK_FACTOR, function(err, salt) {
+    if (err) {
+      return next(err)
+    }
+
+    bcrypt.hash(user.password, salt, function(err, hash) {
+      if (err) {
+        return next(err)
+      }
+
+      user.password = hash
+      next()
+    })
+  })
+})
+
+adminUserSchema.methods.comparePassword = function comparePassword(candidatePassword) {
+  return new Promise((resolve, reject) => {
+    bcrypt.compare(candidatePassword, this.password, function(err, isMatch) {
+      if (err) {
+        return reject(err)
+      }
+      resolve(isMatch)
+    })
+  })
+}
+
+module.exports = mongoose.model('AdminUser', adminUserSchema)

--- a/backend/app/models/index.js
+++ b/backend/app/models/index.js
@@ -10,6 +10,7 @@ const Committee = require('./committee')
 const Subcommittee = require('./subcommittee')
 const RepresentativeCommittee = require('./representativeCommittee')
 const RepresentativeSubcommittee = require('./representativeSubcommittee')
+const AdminUser = require('./adminUser')
 
 module.exports = {
   User,
@@ -23,5 +24,6 @@ module.exports = {
   Committee,
   Subcommittee,
   RepresentativeCommittee,
-  RepresentativeSubcommittee
+  RepresentativeSubcommittee,
+  AdminUser
 }

--- a/backend/app/utilities/auth.js
+++ b/backend/app/utilities/auth.js
@@ -1,0 +1,29 @@
+const auth = require('basic-auth')
+const jwt = require('jsonwebtoken')
+
+const { AdminUser } = require('../models')
+
+async function handleAuthTokenRequest(req, res) {
+  const user = auth(req)
+
+  if (!user || !user.name || !user.pass) {
+    return res.sendStatus(401)
+  }
+
+  const adminUser = await AdminUser.findOne({ username: user.name }).exec()
+  if (!adminUser) {
+    return res.sendStatus(401)
+  }
+
+  const isPasswordMatch = await adminUser.comparePassword(user.pass)
+  if (!isPasswordMatch) {
+    return res.sendStatus(401)
+  }
+
+  const token = jwt.sign({ bot: adminUser.bot }, process.env.JWT_SECRET, { expiresIn: '2h' })
+  res.json({ token: token })
+}
+
+module.exports = {
+  handleAuthTokenRequest
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "any-promise": "^1.3.0",
     "basic-auth": "^1.1.0",
     "basic-auth-connect": "^1.0.0",
+    "bcrypt": "^1.0.2",
     "body-parser": "^1.15.1",
     "common-tags": "^1.4.0",
     "dotenv": "^2.0.0",

--- a/backend/server.js
+++ b/backend/server.js
@@ -59,6 +59,7 @@ if (process.env.DEBUG_ENDPOINTS === 'true') {
   unauthenticatedPaths.push(new RegExp('/api/start/.*', 'i'))
   unauthenticatedPaths.push(new RegExp('/api/send/.*', 'i'))
 }
+// all authenticated API endpoints will have access to the current user's bot at req.user.bot
 app.use(jwt({ secret: process.env.JWT_SECRET }).unless({
   path: unauthenticatedPaths,
 }))


### PR DESCRIPTION
Resolves #288 

* Create an `AdminUser` model for storing authentication credentials for admin users
* Encode the admin user's bot in their auth token, and limit data from the backend to only their bot's data 