### PR TITLE
Pass the current AdminUser to all routes that require authentication

### DIFF
--- a/backend/app/methods/adminMethods.js
+++ b/backend/app/methods/adminMethods.js
@@ -4,7 +4,7 @@ const { logMessage } = require('../utilities/logHelper')
 exports.newAdmin = async function(req, res) {
 
   // only callparty user can create admin
-  const bot = req.user.bot
+  const bot = req.adminUser.bot
   if (['callparty', 'callingteststaging'].indexOf(bot) < 0) {
     throw new Error('++ only callparty users can create admin')
   }
@@ -38,8 +38,8 @@ exports.newAdmin = async function(req, res) {
 }
 
 exports.getCurrentAdmin = async function(req, res) {
-  const bot = req.user.bot
-  const currentAdmin = await AdminUser.findOne({bot: bot})
+  const bot = req.adminUser.bot
+  const currentAdmin = await AdminUser.findOne({ bot: bot })
   res.json({
     username: currentAdmin.username,
     bot: currentAdmin.bot,

--- a/backend/app/methods/adminMethods.js
+++ b/backend/app/methods/adminMethods.js
@@ -38,10 +38,8 @@ exports.newAdmin = async function(req, res) {
 }
 
 exports.getCurrentAdmin = async function(req, res) {
-  const bot = req.adminUser.bot
-  const currentAdmin = await AdminUser.findOne({ bot: bot })
   res.json({
-    username: currentAdmin.username,
-    bot: currentAdmin.bot,
+    username: req.adminUser.username,
+    bot: req.adminUser.bot,
   })
 }

--- a/backend/app/methods/campaignMethods.js
+++ b/backend/app/methods/campaignMethods.js
@@ -7,7 +7,7 @@ const ObjectId = mongoose.Types.ObjectId
 exports.newCampaign = function(req, res) {
 
   // get bot from currently logged in admin
-  const bot = req.user.bot
+  const bot = req.adminUser.bot
 
   // process request
   const data = req.body
@@ -25,7 +25,7 @@ exports.newCampaign = function(req, res) {
 exports.modifyCampaign = function(req, res) {
 
   // get bot from currently logged in admin
-  const bot = req.user.bot
+  const bot = req.adminUser.bot
 
   // update campaign
   return Campaign.update({_id: req._id, bot: bot}, {
@@ -43,7 +43,7 @@ exports.modifyCampaign = function(req, res) {
 exports.getCampaign = function(req, res) {
 
   // get bot from currently logged in admin
-  const bot = req.user.bot
+  const bot = req.adminUser.bot
 
   // return campaign
   return Campaign
@@ -62,7 +62,7 @@ exports.getCampaign = function(req, res) {
 
 exports.getCampaigns = function(req, res) {
   // get bot from currently logged in admin
-  const bot = req.user.bot
+  const bot = req.adminUser.bot
 
   // return campaigns
   Campaign
@@ -82,7 +82,7 @@ exports.getCampaigns = function(req, res) {
 exports.newCampaignAction = async function(req, res) {
 
   // get bot from currently logged in admin
-  const bot = req.user.bot
+  const bot = req.adminUser.bot
 
   // assert that campaign.bot is the same as currently logged in bot
   const campaign = await Campaign.findOne({ _id: req.params.id, bot: bot })

--- a/backend/app/routes/adminRoutes.js
+++ b/backend/app/routes/adminRoutes.js
@@ -26,7 +26,7 @@ module.exports = function(apiRouter) {
   apiRouter.get('/campaign_actions/:id', async function(req, res) {
 
     // get bot from currently logged in admin
-    const bot = req.user.bot
+    const bot = req.adminUser.bot
 
     // process request
     const { type } = await CampaignAction.findOne({ _id: req.params.id, bot: bot }).select({ type: 1, _id: 0 }).exec()
@@ -47,7 +47,7 @@ module.exports = function(apiRouter) {
   apiRouter.get('/clone_action/:id', async function(req, res) {
 
     // get bot from currently logged in admin
-    const bot = req.user.bot
+    const bot = req.adminUser.bot
 
     /* this function returns a campaign action without its virtuals populated (to be used as a clone input) */
     const { type } = await CampaignAction.findOne({ _id: req.params.id, bot: bot }).select({ type: 1, _id: 0 }).exec()

--- a/backend/app/utilities/auth.js
+++ b/backend/app/utilities/auth.js
@@ -20,10 +20,18 @@ async function handleAuthTokenRequest(req, res) {
     return res.sendStatus(401)
   }
 
-  const token = jwt.sign({ bot: adminUser.bot }, process.env.JWT_SECRET, { expiresIn: '2h' })
+  const token = jwt.sign({ adminUserId: adminUser._id }, process.env.JWT_SECRET, { expiresIn: '2h' })
   res.json({ token: token })
 }
 
+async function adminUserMiddleware(req, res, next) {
+  if (req.user && req.user.adminUserId) {
+    req.adminUser = await AdminUser.findById(req.user.adminUserId).exec()
+  }
+  next()
+}
+
 module.exports = {
-  handleAuthTokenRequest
+  handleAuthTokenRequest,
+  adminUserMiddleware
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -64,6 +64,10 @@ app.use(jwt({ secret: process.env.JWT_SECRET }).unless({
   path: unauthenticatedPaths,
 }))
 
+const { adminUserMiddleware } = require('./app/utilities/auth')
+
+app.use(adminUserMiddleware)
+
 // routes
 require('./app/routes/helperRoutes')(apiRouter)
 require('./app/routes/sendRoutes')(apiRouter, io)

--- a/frontend/app/App.js
+++ b/frontend/app/App.js
@@ -21,6 +21,7 @@ class Container extends Component {
       loaded: false,
     }
     this.refreshReps = this.refreshReps.bind(this)
+    this.fetchCurrentAdmin = this.fetchCurrentAdmin.bind(this)
   }
 
   static get contextTypes() {
@@ -31,7 +32,7 @@ class Container extends Component {
     this.fetchCurrentAdmin()
   }
 
-  fetchCurrentAdmin = () => {
+  fetchCurrentAdmin() {
     return API.getCurrentAdmin().then(data => {
       this.setState({ currentAdmin: data, loaded: true })
     })


### PR DESCRIPTION
* Encode the current logged in `AdminUser`'s id in the auth token instead of their bot's name
* Add express middleware that finds the current `AdminUser` based on the id decoded from their auth token