### PR TITLE
Optimize campaigns and campaign endpoint

### DIFF
--- a/backend/app/methods/campaignCallMethods.js
+++ b/backend/app/methods/campaignCallMethods.js
@@ -1,10 +1,9 @@
 const { CampaignCall } = require('../models')
 const { getPopulatedCampaignCallObject } = require('../utilities/campaignCalls')
 
-function getCampaignCallDetail(req, res) {
-  return getPopulatedCampaignCallObject(req.params.id)
-    .then(campaignCallObject => res.json(campaignCallObject))
-    .catch(err => res.send(err))
+async function getCampaignCallDetail(req, res) {
+  const campaignCall = await getPopulatedCampaignCallObject(req.params.id)
+  return res.json(campaignCall)
 }
 
 function getCampaignCall(req, res) {

--- a/backend/app/methods/campaignMethods.js
+++ b/backend/app/methods/campaignMethods.js
@@ -69,10 +69,7 @@ exports.getCampaigns = async function(req, res) {
   Campaign
     .find({bot: bot})
     .populate({
-      path: 'campaignActions',
-      populate: {
-        path: 'userConversations'
-      }
+      path: 'campaignActions'
     })
     .exec(function(err, campaigns) {
       if (err) return res.send(err)

--- a/backend/app/methods/campaignMethods.js
+++ b/backend/app/methods/campaignMethods.js
@@ -51,9 +51,6 @@ exports.getCampaign = function(req, res) {
     .findOne({ _id: req.params.id, bot: bot })
     .populate({
       path: 'campaignActions',
-      populate: {
-        path: 'userConversations'
-      }
     })
     .exec(function(err, campaign) {
       if (err) return res.send(err)

--- a/backend/app/models/user.js
+++ b/backend/app/models/user.js
@@ -34,7 +34,13 @@ userSchema.virtual('userConversations', {
 })
 
 userSchema.virtual('botId').get(function() {
-  return this.bot._id
+  // TODO: figure out why for some users bot is null
+  if (this.bot) {
+    return this.bot._id
+  }
+  else {
+    return null
+  }
 })
 
 module.exports = mongoose.model('User', userSchema)

--- a/frontend/app/Campaign.js
+++ b/frontend/app/Campaign.js
@@ -111,12 +111,14 @@ class Campaign extends Component {
     this.state = {
       campaignActions: [],
       title: '',
+      loaded: false,
     }
   }
 
   componentWillMount() {
     API.campaign(this.props.params.id, data => {
       this.setState(data)
+      this.setState({loaded: true})
     })
   }
 
@@ -137,34 +139,37 @@ class Campaign extends Component {
     })
 
     return (
-      <div className="campaign">
-        <div className="meta">
-          <h1>Campaign: <span>{this.state.title}</span></h1>
-          <p>Description: {this.state.description}</p>
-          <p>Created at {createdAt}</p>
-        </div>
-        <div className="table">
-          <div className="table-header">
-            <h2>Conversations</h2>
-            <div className="table-header-buttons">
-              <Link className="button" to={`/${this.props.params.id}/call/new`}>New Call</Link>
-              <Link className="button" to={`/${this.props.params.id}/update/new`}>New Message</Link>
-            </div>
+      <Loader loaded={this.state.loaded}>
+        <div className="campaign">
+          <div className="meta">
+            <h1>Campaign: <span>{this.state.title}</span></h1>
+            <p>Description: {this.state.description}</p>
+            <p>Created at {createdAt}</p>
           </div>
-          <table>
-            <tbody>
-              <tr>
-                <th>#</th>
-                <th>Type</th>
-                <th>Label</th>
-                <th>Date Created</th>
-                <th>Clone?</th>
-              </tr>
-              {campaignActions}
-            </tbody>
-          </table>
+          <div className="table">
+            <div className="table-header">
+              <h2>Conversations</h2>
+              <div className="table-header-buttons">
+                <Link className="button" to={`/${this.props.params.id}/call/new`}>New Call</Link>
+                <Link className="button" to={`/${this.props.params.id}/update/new`}>New Message</Link>
+              </div>
+            </div>
+            <table>
+              <tbody>
+                <tr>
+                  <th>#</th>
+                  <th>Type</th>
+                  <th>Label</th>
+                  <th>Date Created</th>
+                  <th>Clone?</th>
+                </tr>
+                {campaignActions}
+              </tbody>
+            </table>
+          </div>
         </div>
-      </div>)
+      </Loader>
+    )
   }
 }
 

--- a/frontend/app/CampaignActionDetail.js
+++ b/frontend/app/CampaignActionDetail.js
@@ -212,7 +212,7 @@ export default class CampaignActionDetail extends React.Component {
     let targeting = []
     if (this.state.action.targetingType === 'segmenting') {
       targeting = [memberTypeTargeting, ...partyTargeting, ...committeeTargeting, ...districtTargeting]
-    } else if (this.state.action.targetingType === 'borrowed') {
+    } else if (this.state.action.targetingType === 'borrowed' && this.state.action.targetAction) {
       targeting = [`borrowed from: ${this.state.action.targetAction.label} `]
     }
     return (


### PR DESCRIPTION
For some reason we were populating userConversation on each of these endpoints
when they were not needed  

By removing these populate it took response times down from 
17 seconds to 500ms for campaigns
5 seconds to 320ms for campaign detail

The one page that is still sometimes slow is campaignAction detail
to improve the speed of this page, we should make the userConversation table into a paginated table with infinite scroll
--> I created a github issue here: https://github.com/CallParty/CallParty/issues/360

resolves: https://github.com/CallParty/CallParty/issues/358