### PR TITLE
Script updates for nonpartisan and unsubscribe help

### DIFF
--- a/backend/app/conversations/callConvo.js
+++ b/backend/app/conversations/callConvo.js
@@ -66,7 +66,7 @@ async function startCallConversation(user, userConversation, representatives, ca
 function areYouReadyConvo(user) {
   // begin the conversation
   return botReply(user,
-    `Hi ${user.currentConvo.convoData.firstName}. We've got an issue that needs your action.`
+    `Hi ${user.currentConvo.convoData.firstName}. We've got an issue to call about.`
   )
   .then(() => {
     return botReply(user, `${user.currentConvo.convoData.issueMessage} ` +
@@ -164,7 +164,7 @@ function firstTimeAreYouReadyConvo(user) {
 async function firstTimeReadyResponseConvo(user, message) {
   if (!Object.values(ACTION_TYPE_PAYLOADS).includes(message.text)) {
     logMessage(`++ User responded to firstTimeReadyResponseConvo with unexpected message: ${message.text}`)
-    return botReply(user, `I'm sorry, I didn't understand that! Try choosing from one of the options above, or shoot us an email to talk to a person at ${user.bot.orgEmail}.`)
+    return botReply(user, `I'm sorry, I didn't understand that! Try choosing from one of the options above, or shoot us an email to talk to a person at ${user.bot.orgEmail}. You can also say 'stop' or 'unsubscribe' to stop receiving messages.`)
   }
 
   await UserAction.create({
@@ -190,7 +190,7 @@ async function firstTimeReadyResponseConvo(user, message) {
 async function readyResponseConvo(user, message) {
   if (!Object.values(ACTION_TYPE_PAYLOADS).includes(message.text)) {
     logMessage(`++ User responded to readyResponseConvo with unexpected message: ${message.text}`)
-    return botReply(user, `I'm sorry, I didn't understand that! Try choosing from one of the options above, or shoot us an email to talk to a person at ${user.bot.orgEmail}.`)
+    return botReply(user, `I'm sorry, I didn't understand that! Try choosing from one of the options above, or shoot us an email to talk to a person at ${user.bot.orgEmail}. You can also say 'stop' or 'unsubscribe' to stop receiving messages.`)
   }
 
   await UserAction.create({
@@ -211,7 +211,7 @@ async function readyResponseConvo(user, message) {
       When you call:
 
       \u2022 Be sure to say you're a constituent calling about ${user.currentConvo.convoData.issueSubject}
-      \u2022 Let them know "I'd like ${representative.repTitle} to ${user.currentConvo.convoData.issueTask}"
+      \u2022 Let them know you'd like ${representative.repTitle} to ${user.currentConvo.convoData.issueTask}
       \u2022 Share any personal feelings or stories you have on the issue
       \u2022 Answer any questions the staffer has, and be friendly!
     `
@@ -220,7 +220,7 @@ async function readyResponseConvo(user, message) {
       Great! You'll be calling ${user.currentConvo.convoData.representatives.length} Members of Congress. You'll either talk to a staffer or leave a voicemail. When you call:
 
       \u2022 Be sure to say you're a constituent calling about ${user.currentConvo.convoData.issueSubject}
-      \u2022 Let them know you'd like them to "${user.currentConvo.convoData.issueTask}"
+      \u2022 Let them know you'd like them to ${user.currentConvo.convoData.issueTask}
       \u2022 Share any personal feelings or stories you have on the issue
       \u2022 Answer any questions the staffer has, and be friendly!
 
@@ -519,7 +519,7 @@ function somethingWentWrongResponse(user) {
 async function howDidItGoResponseConvo(user, message) {
   if (!Object.values(ACTION_TYPE_PAYLOADS).includes(message.text)) {
     logMessage(`++ User responded to howDidItGoResponseConvo with unexpected message: ${message.text}`)
-    return botReply(user, `I'm sorry, I didn't understand that! Try choosing from one of the options above, or shoot us an email to talk to a person at ${user.bot.orgEmail}.`)
+    return botReply(user, `I'm sorry, I didn't understand that! Try choosing from one of the options above, or shoot us an email to talk to a person at ${user.bot.orgEmail}. You can also say 'stop' or 'unsubscribe' to stop receiving messages.`)
   }
 
   await UserAction.create({
@@ -541,7 +541,7 @@ async function howDidItGoResponseConvo(user, message) {
 async function tryNextRepResponseConvo(user, message) {
   if (!Object.values(ACTION_TYPE_PAYLOADS).includes(message.text)) {
     logMessage(`++ User responded to tryNextRepResponseConvo with unexpected message: ${message.text}`)
-    return botReply(user, `I'm sorry, I didn't understand that! Try choosing from one of the options above, or shoot us an email to talk to a person at ${user.bot.orgEmail}.`)
+    return botReply(user, `I'm sorry, I didn't understand that! Try choosing from one of the options above, or shoot us an email to talk to a person at ${user.bot.orgEmail}. You can also say 'stop' or 'unsubscribe' to stop receiving messages.`)
   }
 
   await UserAction.create({

--- a/backend/app/conversations/defaultConvo.js
+++ b/backend/app/conversations/defaultConvo.js
@@ -10,7 +10,7 @@ function defaultConvo(user, message) {
 
   const replyMessage = shouldReplyWithThumbsUp ?
     `👍` :
-    `I'm sorry, I didn't understand that! If you have a question, comment, or suggestion, a real person will respond here shortly. You can also email us at ${user.bot.orgEmail}.`
+    `I'm sorry, I didn't understand that! Shoot us an email if you'd like to talk to a person ${user.bot.orgEmail}. You can also say 'stop' or 'unsubscribe' to stop receiving messages.`
 
   return botReply(user, replyMessage)
 }


### PR DESCRIPTION
**Fixes:**
Sending nonpartisan calls scripts was difficult because of the parenthetical formatting.

Recipients had difficulty unsubscribing, and get frustrated hitting the unexpected message over and over.

Examples of new call script:

- Let them know you’d like [repType] [repName] to [issueTask]
- Let them know you'd like [Senator] [Schumer] to [either let DACA end without replacement or codify DACA into law]
- Let them know you'd like [Senator] [Schumer] to [oppose the Graham-Cassidy bill, which would leave millions without coverage]

Edit by oren:
closes #381 
closes #366 
