### PR TITLE
changes override temporarily to not override

### DIFF
--- a/backend/app/utilities/listener.js
+++ b/backend/app/utilities/listener.js
@@ -49,7 +49,7 @@ async function handleEcho(senderId, recipientId, message) {
     // if they do exist, then change the callback of the user to override
     else {
       logMessage(`++ setting user to override mode ${recipientId}`, '#_override')
-      setUserCallback(user, '/override')
+      setUserCallback(user, '/calltoaction/readyResponse')
     }
   }
 }


### PR DESCRIPTION
This will help put users on the readyResponse callback path so that we can get them back on track quickly. This will be undone after the campaign is fixed.